### PR TITLE
open_flags shall be declared extern in header

### DIFF
--- a/ffsmark_core.h
+++ b/ffsmark_core.h
@@ -65,6 +65,6 @@ int ffsmark_hooks_pre_files_deletion();
 int ffsmark_hooks_pre_subdirs_deletion();
 int ffsmark_hooks_post_subdirs_deletion();
 
-int open_flags;
+extern int open_flags;
 
 #endif /* FFSMARK_CORE_H */


### PR DESCRIPTION
else the variable is instanciated in ffsmark_core.o and postmark.o, leading to a linking error